### PR TITLE
use ntp check error instead of string

### DIFF
--- a/src/checks/ntp_check.go
+++ b/src/checks/ntp_check.go
@@ -6,10 +6,8 @@ import (
 )
 
 func NtpCheck() error {
-	stdout, _, _ := RunCommand("w32tm /resync")
-	if strings.Contains(stdout, "The command completed successfully") {
-		return nil
-	} else {
+	_, _, err := RunCommand("w32tm /resync")
+	if err != nil {
 		return errors.New(`
 There was an error detecting ntp synchronization on your machine.
 An accurate system clock is essential for internal Cloud Foundry metric reports.
@@ -18,4 +16,6 @@ Please configure your NTP settings, if not already done.
 We recommend that your firewall have outbound rules set for UDP on port 123.
 In addition, ensure that your 'DnsCache' service is running.  ` + "Error: \n\n" + stdout)
 	}
+	
+	return nil
 }


### PR DESCRIPTION
fixes: https://github.com/cloudfoundry-incubator/hakim/issues/2

- no english OSes do not return the same string
- exec.Cmd.Run returns a non nil error if the command did not complete with a 0 exit code